### PR TITLE
Add robots.txt file with sitemap.xml specified

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Sitemap: {{% .Site.BaseURL %}}sitemap.xml


### PR DESCRIPTION
Because by default Hugo generates sitemap, we should also point to it in the robots.txt file.